### PR TITLE
#56 Replaced ':' in key-value pairs with '='

### DIFF
--- a/interface/fast/src/Fast_StaticInitializer.c
+++ b/interface/fast/src/Fast_StaticInitializer.c
@@ -81,7 +81,12 @@ db_word Fast_Initializer_offset(Fast_StaticInitializer _this, db_uint32 variable
                     }
                     db_rbtreeSet(*(db_rbtree*)base, (void*)_this->frames[fp].keyPtr[variable], (void*)result);
                     if (!result) {
-                        result = (db_word)db_rbtreeGetPtr(*(db_rbtree*)base, (void*)_this->frames[fp].keyPtr[variable]);
+                        if (_this->frames[fp].keyPtr[variable]) {
+                            result = (db_word)db_rbtreeGetPtr(*(db_rbtree*)base, (void*)_this->frames[fp].keyPtr[variable]);
+                        } else {
+                            Fast_Parser_error(yparser(), "cannot set element without keyvalue");
+                            goto error;
+                        }
                     }
                 } else {
                     result = (db_word)db_calloc(db_type_sizeof(keyType));

--- a/interface/fast/src/fast.y
+++ b/interface/fast/src/fast.y
@@ -361,8 +361,8 @@ init_list_colon
     ;
 
 init_colon
-    : any_id ':' {Fast_Parser_initMember(yparser(), $1); fast_op;} init_value
-    | init_key ':' init_value
+    : any_id '=' {Fast_Parser_initMember(yparser(), $1); fast_op;} init_value
+    | init_key '=' init_value
     ;
 
 init_key

--- a/test/language/tc_compare04.hyve
+++ b/test/language/tc_compare04.hyve
@@ -15,9 +15,9 @@ Point p1: 10,20;
 Point p2: 15,20;
 Point p3: 10,25;
 
-Line l1: start:{10,20} stop:{30,40};
-Line l2: start:{10,25} stop:{30,40};
-Line l3: start:{10,20} stop:{30,45};
+Line l1: start={10,20} stop={30,40};
+Line l2: start={10,25} stop={30,40};
+Line l3: start={10,20} stop={30,45};
 
 // Point
 if p1.compare(p2) != LT: fail("p1.compare(p2) (${p1.compare(p2)} != LT)");

--- a/test/language/tc_compare06.hyve
+++ b/test/language/tc_compare06.hyve
@@ -16,16 +16,16 @@ struct Polygon::
 	points_1 : list{Point};
 	points_2 : list{Point};
 
-Line l1: points_1:{{10,20}, {30,40}} points_2:{{50,60},{70,80}};
-Line l2: points_1:{{10,20}, {30,40}} points_2:{{50,60},{70,85}};
+Line l1: points_1={{10,20}, {30,40}} points_2={{50,60},{70,80}};
+Line l2: points_1={{10,20}, {30,40}} points_2={{50,60},{70,85}};
 
 if l1.compare(l2) != LT: fail("l1.compare(l2) (${l1.compare(l2)} != LT)");
 if l2.compare(l1) != GT: fail("l2.compare(l1) (${l2.compare(l1)} != GT)");
 if l1.compare(l1) != EQ: fail("l1.compare(l1) (${l1.compare(l1)} != EQ)");
 
-Polygon p1: points_1:{{10,20}, {30,40}} points_2:{{50,60},{70,80}};
-Polygon p2: points_1:{{10,20}, {30,40}} points_2:{{50,60},{70,85}};
-Polygon p3: points_1:{{10,20}, {30,40}} points_2:{{50,60},{70,80},{90,100}};
+Polygon p1: points_1={{10,20}, {30,40}} points_2={{50,60},{70,80}};
+Polygon p2: points_1={{10,20}, {30,40}} points_2={{50,60},{70,85}};
+Polygon p3: points_1={{10,20}, {30,40}} points_2={{50,60},{70,80},{90,100}};
 
 if p1.compare(p2) != LT: fail("p1.compare(p2) (${p1.compare(p2)} != LT)");
 if p2.compare(p1) != GT: fail("p2.compare(p1) (${p2.compare(p1)} != GT)");

--- a/test/language/tc_element01.hyve
+++ b/test/language/tc_element01.hyve
@@ -14,7 +14,7 @@ typedef IntsMap : map{uint32,string};
 IntsArray ints_aCheck : 10,20,30;
 IntsSeq ints_sCheck : 10,20,30;
 IntsList ints_lCheck : 10,20,30;
-IntsMap ints_mCheck : "a":10 "b":20 "c":30;
+IntsMap ints_mCheck : "a"=10 "b"=20 "c"=30;
 
 void validate(IntsArray c, string failMsg): if c.compare(ints_aCheck): fail(failMsg);
 void validate(IntsSeq c, string failMsg):   if c.compare(ints_sCheck): fail(failMsg);
@@ -43,7 +43,7 @@ ints_l[2] += 27;
 validate(ints_l, "List object with static index");
 
 // Map object
-IntsMap ints_m : "a":1 "b":2 "c":3;
+IntsMap ints_m : "a"=1 "b"=2 "c"=3;
 ints_m["a"] = 10;
 ints_m["b"] *= 10;
 ints_m["c"] += 27;

--- a/test/language/tc_element02.hyve
+++ b/test/language/tc_element02.hyve
@@ -17,7 +17,7 @@ typedef PointsMap : map{Point,string};
 PointsArray ints_aCheck : {10,20},{30,40},{50,60};
 PointsSeq ints_sCheck : {10,20},{30,40},{50,60};
 PointsList ints_lCheck : {10,20},{30,40},{50,60};
-PointsMap ints_mCheck : "a":{10,20} "b":{30,40} "c":{50,60};
+PointsMap ints_mCheck : "a"={10,20} "b"={30,40} "c"={50,60};
 
 void validate(PointsArray c, string failMsg): if c.compare(ints_aCheck): fail(failMsg);
 void validate(PointsSeq c, string failMsg):   if c.compare(ints_sCheck): fail(failMsg);
@@ -55,7 +55,7 @@ ints_l[2].y += 54;
 validate(ints_l, "tc_element02 FAIL: List object with static index");
 
 // Map object
-PointsMap ints_m : "a":{1,2} "b":{3,4} "c":{5,6};
+PointsMap ints_m : "a"={1,2} "b"={3,4} "c"={5,6};
 ints_m["a"].x = 10;
 ints_m["a"].y = 20;
 ints_m["b"].x *= 10;

--- a/test/language/tc_element03.hyve
+++ b/test/language/tc_element03.hyve
@@ -20,7 +20,7 @@ typedef FooMap : map{Foo,string};
 FooArray Foo_aCheck : a,b,c;
 FooSeq Foo_sCheck : a,b,c;
 FooList Foo_lCheck : a,b,c;
-FooMap Foo_mCheck : "a":a "b":b "c":c;
+FooMap Foo_mCheck : "a"=a "b"=b "c"=c;
 
 void validate(FooArray c, string failMsg): if c.compare(Foo_aCheck): fail(failMsg);
 void validate(FooSeq c, string failMsg):   if c.compare(Foo_sCheck): fail(failMsg);
@@ -49,7 +49,7 @@ Foo_l[2] = c;
 validate(Foo_l, "List object with static index");
 
 // Map object
-FooMap Foo_m : "a":null "b":null "c":null;
+FooMap Foo_m : "a"=null "b"=null "c"=null;
 Foo_m["a"] = a;
 Foo_m["b"] = b;
 Foo_m["c"] = c;

--- a/test/language/tc_initializers01.hyve
+++ b/test/language/tc_initializers01.hyve
@@ -36,15 +36,15 @@ void test(Line l, int32 x1, int32 y1, int32 z1, int32 x2, int32 y2, int32 z2, Co
 Color c1 : Red;
 	
 Point3D p1 : 10,20,30;
-Point3D p2 : x:40 y:50 z:60;
-Point3D p3 : x:70 y:80 z:90;
+Point3D p2 : x=40 y=50 z=60;
+Point3D p3 : x=70 y=80 z=90;
 var Point3D p4 = {10,20,30};
 var Point3D& p5 = Point3D{20,30,40};
 var Point3D& p6 = &p5;
 
-Line l1 : {10,20,30},{40,50,60},Red;
-Line l2 : start:{10,20,30} stop:{40,50,60} color:Yellow;
-Line l3 : start:{x:10 y:20 z:30} stop:{x:40 y:50 z:60} color:Blue;
+Line l1 : {10, 20, 30}, {40, 50, 60}, Red;
+Line l2 : start = {10, 20, 30} stop = {40, 50, 60} color = Yellow;
+Line l3 : start = {x=10 y=20 z=30} stop = {x=40 y=50 z=60} color = Blue;
 
 array PointArray : Point3D, 3;
 sequence PointSeq : Point3D;
@@ -63,9 +63,9 @@ PointList pl1 : {10,20,30}, {40,50,60}, {70,80,90};
 PointList pl2 : p1, p2, p3;
 PointList pl3 : Point3D{10,20,30}, Point3D{40,50,60}, Point3D{70,80,90};
 
-PointMap pm1 : "point1":{10,20,30} "point2":{40,50,60} "point3":{70,80,90};
-PointMap pm2 : "point1":p1 "point2":p2 "point3":p3;
-PointMap pm3 : "point1":Point3D{10,20,30} "point2":Point3D{40,50,60} "point3":Point3D{70,80,90};
+PointMap pm1 : "point1"={10,20,30} "point2"={40,50,60} "point3"={70,80,90};
+PointMap pm2 : "point1"=p1 "point2"=p2 "point3"=p3;
+PointMap pm3 : "point1"=Point3D{10,20,30} "point2"=Point3D{40,50,60} "point3"=Point3D{70,80,90};
 
 // Test points
 test(p1, 10, 20, 30, "p1");

--- a/test/language/tc_initializers02.hyve
+++ b/test/language/tc_initializers02.hyve
@@ -37,10 +37,10 @@ Point p2: 30,40;
 Point3D p3: 50,60,70;
 Point3D p4: 80,90,100;
 
-Line l1: start:p1 end:p2;
-Line l2: start:Point{10,20} end:Point{30,40};
-Line l3: start:p3 end:p4;
-Line l4: start:Point3D{10,20,30} end:Point3D{40,50,60};
+Line l1: start=p1 end=p2;
+Line l2: start=Point{10,20} end=Point{30,40};
+Line l3: start=p3 end=p4;
+Line l4: start=Point3D{10,20,30} end=Point3D{40,50,60};
 
 var Point var1 = p1;
 var Point var2 = Point{10,20};

--- a/test/language/tc_member.hyve
+++ b/test/language/tc_member.hyve
@@ -18,28 +18,28 @@ class TriangleHolder::
 	member triangle : ::Triangle;
 
 // var of non-reference type
-var Line lineA = {start:{1,2} end:{3,4}};
+var Line lineA = {start={1,2} end={3,4}};
 lineA.start.x = 10;
 lineA.start.y = lineA.start.x * 2;
 lineA.end.x = 30;
 lineA.end.y = 40;
 
 // 2nd var of non-reference type
-var Line lineB = {start:{1,2} end:{3,4}};
+var Line lineB = {start={1,2} end={3,4}};
 lineB.start.x = lineB.end.y;
 lineB.start.y = 20;
 lineB.end.x *= 10;
 lineB.end.y = 40;
 
 // Object of non-reference type
-Line lineC : start:{1,2} end:{3,4};
+Line lineC : start={1,2} end={3,4};
 lineC.start.x = 10;
 lineC.start.y = (lineC.start.x + 10) * 2;
 lineC.end.x *= 10;
 lineC.end.y = 40;
 
 // Object of reference type
-Triangle triangleB : v1:{1,2} v2:{3,4} v3:{5,6};
+Triangle triangleB : v1={1,2} v2={3,4} v3={5,6};
 triangleB.v1.x = 10;
 triangleB.v1.y *= 20;
 triangleB.v2.x = 30;
@@ -51,7 +51,7 @@ triangleB.v3.y = 60;
 var Triangle triangleA = triangleB;
 
 // Object with reference-member
-Triangle triangleC : v1:{3,4} v2:{5,6} v3:{7,8};
+Triangle triangleC : v1={3,4} v2={5,6} v3={7,8};
 TriangleHolder holder : triangleB;
 if holder.triangle != triangleB:
 	io::println("holder.triangle");


### PR DESCRIPTION
Fixed #56
