### PR TITLE
Revert "#525 Added corto_llReplaceCmp"

### DIFF
--- a/packages/corto/include/ll.h
+++ b/packages/corto/include/ll.h
@@ -44,9 +44,6 @@ void corto_llRemove(corto_ll list, void* o);
 /* Replace object */
 void corto_llReplace(corto_ll list, void* o, void* by);
 
-/* Replace object matched against a comparison function */
-void* corto_llReplaceCmp(corto_ll list, corto_compareAction compare, void* original, void* replacement);
-
 /* Take first */
 void* corto_llTakeFirst(corto_ll);
 

--- a/packages/corto/src/ll.c
+++ b/packages/corto/src/ll.c
@@ -281,21 +281,6 @@ void corto_llReplace(corto_ll list, void* src, void* by) {
     }
 }
 
-void* corto_llReplaceCmp(corto_ll list, corto_compareAction compare, void* original, void* replacement)
-{
-    corto_llNode node = list->first;
-    void* old = NULL;
-    while (node) {
-        if (compare(original, node->data) == 0) {
-            old = node->data;
-            node->data = replacement;
-            break;
-        }
-        node = node->next;
-    }
-    return old;
-}
-
 /* Append one list to another */
 void corto_llAppendList(corto_ll l1, corto_ll l2) {
     corto_llNode ptr;


### PR DESCRIPTION
This reverts commit f7ae8c247b40965a6bb2ab1e3cb2877e8d47b995.

Because this function was emergency-introduced for cortoproject/corto-parser, but has now been removed https://github.com/cortoproject/corto-parser/commit/7ddb6df48d86979f5280cbb1e558e3caba548607