### PR TITLE
Regenerate and delete rakefile with `corto build` and `corto clean`

### DIFF
--- a/build/artefact.rb
+++ b/build/artefact.rb
@@ -111,6 +111,13 @@ CLOBBER.include(".corto/_meta.*")
 CLOBBER.include("include/_load.h")
 CLOBBER.include("include/_interface.h")
 
+if File.exists? "project.json"
+  CLOBBER.include("rakefile")
+  CLOBBER.include("Rakefile")
+  CLOBBER.include("rakefile.rb")
+  CLOBBER.include("Rakefile.rb")
+end
+
 # If packages.txt is empty, clobber it
 if USE_PACKAGE_LOADED.length == 0 then
   CLOBBER.include(".corto/packages.txt")

--- a/build/forward.rb
+++ b/build/forward.rb
@@ -6,7 +6,7 @@ end
 Dir.chdir(File.dirname(Rake.application.rakefile))
 
 if not defined? COMPONENTS then
-    raise "COMPONENTS not specified\n"
+  raise "COMPONENTS not specified\n"
 end
 
 require "#{ENV['CORTO_BUILD']}/subrake"

--- a/build/subrake.rb
+++ b/build/subrake.rb
@@ -7,6 +7,11 @@ task :all => :default
 task :default do
     COMPONENTS.each do |e|
         verbose(VERBOSE)
+        if File.exists? "#{e}/project.json"
+          Dir.chdir(e) do
+            sh "corto rakefile"
+          end
+        end
         sh "rake -f #{e}/rakefile"
     end
 end

--- a/tools/corto/include/cortotool_build.h
+++ b/tools/corto/include/cortotool_build.h
@@ -8,6 +8,7 @@
 extern "C" {
 #endif
 
+corto_int16 cortotool_rakefile(int argc, char *argv[]);
 corto_int16 cortotool_build(int argc, char *argv[]);
 corto_int16 cortotool_rebuild(int argc, char *argv[]);
 corto_int16 cortotool_clean(int argc, char *argv[]);

--- a/tools/corto/src/cortotool.c
+++ b/tools/corto/src/cortotool.c
@@ -168,6 +168,11 @@ int main(int argc, char* argv[]) {
                     goto error;
                 }
                 break;
+            } else if (!strcmp(argv[i], "rakefile")) {
+                if (cortotool_rakefile(argc-1, &argv[i])) {
+                    goto error;
+                }
+                break;
             } else if (!strcmp(argv[i], "build")) {
                 if (cortotool_build(argc-i, &argv[i])) {
                     goto error;


### PR DESCRIPTION
Changed "package.json" to "project.json" because it should support both packages and applications.

`cortotool_build` always tries to regenerate a makefile.

`cortotool_clean` always tries to regenerate a rakefile, and will delete it after it finishes running.

Note: running `corto rebuild` will create a rakefile twice but this is a known and desired behavior.