### PR TITLE
Fix build error on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,10 @@ install:
 
 script:
   - source corto/configure
-  - rake
-  - rake test
+  - cd corto && rake && cd -
+  - cd c-binding && rake && cd -
+  - cd json && rake && cd -
+  - corto build xml
+  - corto build corto-language
+  - corto build test
+  - corto test

--- a/configure
+++ b/configure
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-# This can happen if a shell is sourced from a non-bash process
-if [ "$0" != "/bin/bash" ]; then
-    DIR=`pwd`
-else
-    DIR="$(echo $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd))"
+if ! [ -z ${BASH+x} ]; then
+    CURRENT_SHELL="bash"
 fi
+
+case $CURRENT_SHELL in
+"bash")
+    DIR="$(echo $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd))"
+    ;;
+*)
+    DIR=$(pwd)
+    ;;
+esac
 
 export CORTO_HOME="$HOME/.corto"
 export CORTO_TARGET="$HOME/.corto"


### PR DESCRIPTION
CI on Travis has been broken when trying to build the project with a message like:

```
$ rake
rake aborted!
LoadError: cannot load such file -- /home/travis/.corto/lib/corto/1.0/build/forward
```

The cause is that the detection of the current shell (whether bash, zsh, etc.) is faulty. When called from Bash, the script might not detect that the current shell is indeed Bash.

Example build before fix: https://travis-ci.org/cortoproject/corto/jobs/236822442

Example build after fix: https://travis-ci.org/cortoproject/corto/jobs/236569188

