### PR TITLE
Write CXXFlags to Rakefile

### DIFF
--- a/build/artefact.rb
+++ b/build/artefact.rb
@@ -105,7 +105,7 @@ if CONFIG == "debug" then
 end
 
 # Crawl src directory to get list of source files
-SOURCES = Rake::FileList["src/**/*.{c,cpp}"] - ALWAYS_REBUILD
+SOURCES = Rake::FileList["src/**/*.{c,cpp,cxx}"] - ALWAYS_REBUILD
 OBJECTS = SOURCES.
           ext(".o").
           pathmap(".corto/%{^src/,obj/#{CORTO_PLATFORM}/}p") +
@@ -359,7 +359,7 @@ def build()
   verbose(VERBOSE)
 
   # Check if there were any new files created during code generation
-  files = Rake::FileList["src/*.{c,cpp}"] - ALWAYS_REBUILD
+  files = Rake::FileList["src/*.{c,cpp,cxx}"] - ALWAYS_REBUILD
   files.each do |file|
     obj = file.ext(".o").pathmap(".corto/obj/#{CORTO_PLATFORM}/%f")
     if not OBJECTS.include? obj

--- a/tools/corto/src/cortotool_build.c
+++ b/tools/corto/src/cortotool_build.c
@@ -98,6 +98,9 @@ static corto_int16 cortotool_writeRakefileFromPackage(corto_package package)
     if (corto_ll_size(package->cflags)) {
         cortotool_printCortoListAsRubyArray(rakefile, "CFLAGS", package->cflags);
     }
+    if (corto_ll_size(package->cxxflags)) {
+        cortotool_printCortoListAsRubyArray(rakefile, "CXXFLAGS", package->cxxflags);
+    }
     if (!package->managed) {
         fprintf((FILE*)rakefile, "NOCORTO = true\n");
     }
@@ -395,7 +398,7 @@ corto_int16 cortotool_clean(int argc, char *argv[]) {
             verbose ? "verbose=true" : "verbose=false",
             NULL
           }, silent != NULL, mute != NULL);
-        
+
         /* Reset to previous CWD if there is more than one project to build */
         corto_chdir(cwd);
 


### PR DESCRIPTION
Sander configured build system to use CXXFlag attribute in projects.json file, but forgot to update corto build tool to write CXXFlags to rakefile. 